### PR TITLE
Update Dropbox dependency from 2.x to 3.1.2 series

### DIFF
--- a/DropboxBrowser.podspec
+++ b/DropboxBrowser.podspec
@@ -15,13 +15,13 @@ Dropbox Browser provides a simple and effective way to browse, search, and downl
   s.authors            = { "Daniel Bierwirth" => "", "Sam Spencer" => ""}
   s.social_media_url   = "http://danielbierwirth.com"
   
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, "9.0"
 
   s.source       = { :git => "https://github.com/danielbierwirth/DropboxBrowser.git", :tag => "v6.0.1" }
   s.source_files  = "ODB Classes/*.{h,m}"
   s.resource  = "DropboxMedia.xcassets"
 
   s.requires_arc = true
-  s.dependency "ObjectiveDropboxOfficial", "~> 2.0.6"
+  s.dependency "ObjectiveDropboxOfficial", "~> 3.1.2"
 
 end

--- a/ODB Classes/ODBTableViewController.m
+++ b/ODB Classes/ODBTableViewController.m
@@ -140,9 +140,9 @@
             
             // Setup the "Login" action
             [loginAlert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Login", @"DropboxBrowser: Alert Button.") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                [DropboxClientsManager authorizeFromController:[UIApplication sharedApplication] controller:self openURL:^(NSURL *url) {
-                    [[UIApplication sharedApplication] openURL:url];
-                } browserAuth:self.accessPromptCanExit];
+              [DBClientsManager authorizeFromController:[UIApplication sharedApplication] controller:self openURL:^(NSURL *url) {
+                [[UIApplication sharedApplication] openURL:url];
+              }];
             }]];
             
             // Cancel login and dismiss the Browser.


### PR DESCRIPTION
Dropbox Browser is using a fairly old version of the base Dropbox SDK. Most of the changes are naming only to standardize on the DB* namespace.

However this does require bumping minimum iOS version to 9.0 because of Dropbox dropping support upstream. 